### PR TITLE
Revert "Changed ubuntu version to 22.04"

### DIFF
--- a/Vita3KBot/APIClients/GithubClient/GithubClient.cs
+++ b/Vita3KBot/APIClients/GithubClient/GithubClient.cs
@@ -17,7 +17,7 @@ namespace APIClients {
                 return release.Name.StartsWith("windows-latest");
             }).First();
             ReleaseAsset linuxRelease = latestRelease.Assets.Where(release => {
-                return release.Name.StartsWith("ubuntu-22.04");
+                return release.Name.StartsWith("ubuntu-latest");
             }).First();
             ReleaseAsset appimageRelease = latestRelease.Assets.Where(release => {
                 return release.Name.StartsWith("Vita3K-x86_64.AppImage");


### PR DESCRIPTION
Reverts Vita3K/Vita3KBot#49
It was not a good idea to change the artifact name because the update script depends on the artifact name.